### PR TITLE
fixes for version 2.3

### DIFF
--- a/LetterBuilder.hta
+++ b/LetterBuilder.hta
@@ -18,6 +18,7 @@
 		window.moveTo 0, 0
 	</SCRIPT>
 
+	<script type="text/javascript" language="javascript" src="Src/LetterBuilder/LetterBuilder.js"></script>
 	<script type="text/vbscript" language="vbscript" src="Src/LetterBuilder/LetterBuilder.vbs"></script>
 </head>
 
@@ -31,7 +32,7 @@
 
 		<div class="col-xs-12">
 			<!-- Language Switch -->
-			<div id="languageToggleSection" class="col-xs-8 col-xs-offset-4">
+			<div id="languageToggleSection" class="col-xs-8 col-xs-offset-4" style="padding-right: 32px">
 				<a href="#" id="languageEnglish" onClick="TranslateScreen('en', event)">English</a>
 				<a href="#" id="languageFrench" onClick="TranslateScreen('fr', event)">Français</a>
 			</div>
@@ -82,7 +83,7 @@
 
 				<div class="col-xs-8 col-xs-offset-2 form-field">
 					<label id="page1EffectiveDate" for="inputEffectiveDate">Effective Date of Pay Action</label>
-					<input type="text" id="inputEffectiveDate" class="cadField" name="inputEffectiveDate" oninput="EffectiveDateFormatting(event)" disabled>
+					<input type="text" id="inputEffectiveDate" class="cadField" name="inputEffectiveDate" oninput="EffectiveDateFormatting(event)" disabled placeholder="DD/MM/YYYY"></input>
 				</div>
 			</div>
 
@@ -137,7 +138,7 @@
 				</div>
 			</div>
 			<div class="page1-recheckButtonbar" id="recheck-install">
-				<button class="secondaryButton" onClick="CheckInstall()">
+				<button id="retryButton" class="secondaryButton" onClick="CheckInstall()">
 					<img class="button-icon" src="assets/img/reload.png" alt="Reload" />
 					<span id="page1RetryButton">
 						Retry
@@ -164,8 +165,8 @@
 					</ul>
 				</div>
 			</div>
-			<div class="actionBar">
-				<button class="actionButton" id="page3ButtonNext" onClick="GoToPage(4,event)">Next</button>
+			<div class="actionBar col-xs-12">
+				<button class="actionButton pull-right" style="margin-right: 32px;" id="page3ButtonNext" onClick="GoToPage(4,event)">Next</button>
 			</div>
 		</div>
 
@@ -205,7 +206,7 @@
 
 						<div class="col-xs-6 form-field">
 							<label id="EffectiveDateLabel" for="EffectiveDate">Effective Date</label>
-							<input id="EffectiveDate" type="text" class="cadField" name="EffectiveDate" oninput="EffectiveDateFormatting(event)">
+							<input id="EffectiveDate" type="text" class="cadField" name="EffectiveDate" oninput="EffectiveDateFormatting(event)" placeholder="DD/MM/YYYY">
 						</div>
 
 						<div class="col-xs-6 form-field">
@@ -317,16 +318,17 @@
 									<div id="DCPPlanNoLabel" class="mrgn col-xs-12 text-left mrgn-bttm-0 mrgn-tp-0">DCP Plan #</div>
 									<div class="form-field col-xs-12 mrgn-bttm-0 mrgn-tp-0" style="padding: 0; padding-left: 14px;">
 										<select id="DCPPlanNo" name="DCPPlanNo" class="cadField">
+											<option id="DCP-Option-Default" value="">Select Plan</option>
 											<option value="55555"> 55555 </option>
 											<option value="55556"> 55556 </option>
 										</select>
 									</div>
 								</div>
 
-								<div class="col-xs-5">
+								<div class="col-xs-7">
 									<div id="CertificateNumberLabel" class="mrgn col-xs-12 text-left mrgn-bttm-0 mrgn-tp-0">Certificate #</div>
 									<div class="form-field col-xs-12 mrgn-bttm-0 mrgn-tp-0" style="padding: 0; padding-left: 14px;">
-										<input id="DCPCertNo" type="text" class="cadField" name="DCPCertNo">
+										<input id="DCPCertNo" type="text" class="cadField" name="DCPCertNo" placeholder="XX######">
 									</div>
 								</div>
 							</div>
@@ -502,7 +504,7 @@
 			</div>
 
 			<div class="actionBar col-xs-12">
-				<button class="actionButton pull-right" id="page3ButtonGenerate" onClick="GoToPage(5,event)">Generate Letter</button>
+				<button class="actionButton pull-right" style="margin-right: 32px" id="page3ButtonGenerate" onClick="GoToPage(5,event)">Generate Letter</button>
 			</div>
 		</div>
 

--- a/src/LetterBuilder/LetterBuilder.js
+++ b/src/LetterBuilder/LetterBuilder.js
@@ -27,6 +27,8 @@ function placeholderPolyfill(id) {
     var input = document.getElementById(id)
     var placeholderText = document.getElementById(id + "-placeholder")
 
+    if (!input || !placeholderText) return;
+
     if (input.hasAttribute("placeholder") && input.value != "")
         placeholderText.textContent = ""
     else

--- a/src/LetterBuilder/LetterBuilder.js
+++ b/src/LetterBuilder/LetterBuilder.js
@@ -1,0 +1,67 @@
+window.addEventListener("load", load)
+
+function load() {
+    var inputs = document.getElementsByTagName("INPUT");
+
+    backspacePolyfill()
+
+    //Goes through each input
+    for (var i = 0; i < inputs.length; i++) {
+        if (inputs[i].hasAttribute("placeholder"))
+            addPlaceholderText(inputs[i])
+    }
+}
+
+//Polyfill to listening to backspace events
+function backspacePolyfill() {
+    document.addEventListener('selectionchange', function () {
+        var element = document.activeElement;
+
+        if (element.tagName === 'INPUT' && element.type === 'text')
+            placeholderPolyfill(element.id)
+    });
+}
+
+//Polyfill for placeholder text on inputs
+function placeholderPolyfill(id) {
+    var input = document.getElementById(id)
+    var placeholderText = document.getElementById(id + "-placeholder")
+
+    if (input.value != "")
+        placeholderText.textContent = ""
+    else
+        placeholderText.textContent = input.getAttribute("placeholder")
+}
+
+//Attaches a placeholder text element over an input
+function addPlaceholderText(input) {
+    input.addEventListener("input", function (event) {
+        placeholderPolyfill(event.target.id)
+    })
+
+    //Create placeholder text
+    var placeHolderText = document.createElement("p");
+    placeHolderText.textContent = input.getAttribute("placeholder");
+    placeHolderText.className = "placeholder";
+    placeHolderText.id = input.id + "-placeholder";
+
+    var inputParent = input.parentElement;
+
+    //Since elements can't be placed inside <input> tags, we wrap input in a div and add placeholder text to the div.
+    var container = document.createElement("div");
+    container.style.position = "relative";
+    container.className = "form-field"
+    container.style.padding = 0
+
+    //Insert new wrapper div in position of input and place input inside container
+    inputParent.insertBefore(container, input);
+    inputParent.removeChild(input)
+
+    container.appendChild(input);
+    container.appendChild(placeHolderText);
+
+    //IE9 doesnt allow you to disable collision on elements, so when we click the placeholder text, focus the input
+    placeHolderText.addEventListener("click", function (event) {
+        document.getElementById(input.id).select()
+    })
+}

--- a/src/LetterBuilder/LetterBuilder.js
+++ b/src/LetterBuilder/LetterBuilder.js
@@ -17,7 +17,7 @@ function backspacePolyfill() {
     document.addEventListener('selectionchange', function () {
         var element = document.activeElement;
 
-        if (element.tagName === 'INPUT' && element.type === 'text')
+        if (element.tagName === 'INPUT' && element.type === 'text' && element.hasAttribute("placeholder"))
             placeholderPolyfill(element.id)
     });
 }
@@ -27,7 +27,7 @@ function placeholderPolyfill(id) {
     var input = document.getElementById(id)
     var placeholderText = document.getElementById(id + "-placeholder")
 
-    if (input.value != "")
+    if (input.hasAttribute("placeholder") && input.value != "")
         placeholderText.textContent = ""
     else
         placeholderText.textContent = input.getAttribute("placeholder")

--- a/src/LetterBuilder/LetterBuilder.vbs
+++ b/src/LetterBuilder/LetterBuilder.vbs
@@ -228,6 +228,8 @@ Sub ResetData()
     document.getElementById("inputEffectiveDate").value = ""
     document.getElementById("cad-form").reset()
     document.getElementById("pdfFileName").innerHTML = "Placeholder"
+
+    placeholderPolyfill("inputEffectiveDate")
 End Sub
 
 ' Close CAD
@@ -1395,10 +1397,8 @@ Function validateForm()
     ' Validate EffectiveDate
     Set targetElement = document.getElementById("EffectiveDate")
     If validateAndFormatDate(targetElement.value) = "" Then
-        targetElement.parentElement.parentElement.className = "col-xs-6 form-field"
         ToggleWordGenerateButtons(false)
     Else
-        targetElement.parentElement.className = "col-xs-6 form-field"
         ToggleWordGenerateButtons(true)
     End If
     ' Validate DCP Plan No

--- a/src/LetterBuilder/LetterBuilder.vbs
+++ b/src/LetterBuilder/LetterBuilder.vbs
@@ -363,12 +363,12 @@ Sub RunPopulateScreenCADFields(flag)
     Set employeeRecord = GetCADData(0)
     Set employeeTextInputs = document.getElementById("cad-text-inputs")
     Set employeeCheckedInputs = document.getElementById("cad-checked-inputs")
+
     If flag = 0 Then
         UpdateFieldsInElement employeeTextInputs, employeeRecord
     ElseIf flag = 1 Then
         UpdateFieldsInElement employeeCheckedInputs, employeeRecord
     End If
-
 
     If document.getElementById("selectLanguage").value = "French" Then
         document.getElementById("Reason").value = configurationSettings("reason.fr")
@@ -393,15 +393,6 @@ Sub UpdateFieldsInElement(element, employeeRecord)
                 Case "INPUT"
                     If inputField.type = "text" Then
                         inputField.value = employeeRecord(fieldName)
-                        
-                        If(inputField.hasAttribute("placeholder")) Then
-                            If(inputField.value <> "") Then
-                                document.getElementById(inputField.id + "-placeholder").textContent = ""
-                            Else
-                                placeholderText = inputField.getAttribute("placeholder")
-                                document.getElementById(inputField.id + "-placeholder").textContent = placeholderText
-                            End If
-                        End If
                     ElseIf inputField.type = "checkbox" Then
                         If employeeRecord(fieldName) <> "" Then
                         inputField.checked = true
@@ -416,7 +407,18 @@ Sub UpdateFieldsInElement(element, employeeRecord)
                     inputField.value = employeeRecord(fieldName)
             End Select
         End If
+
+        If(inputField.hasAttribute("placeholder")) Then
+            If(Len(inputField.value) > 0) Then
+                document.getElementById(inputField.id + "-placeholder").textContent = ""
+            Else
+                placeholderText = inputField.getAttribute("placeholder")
+                document.getElementById(inputField.id + "-placeholder").textContent = placeholderText
+            End If
+        End If
     Next
+
+    validateForm()
 End Sub
 
 Sub ShowCadField(element, visible)

--- a/src/LetterBuilder/LetterBuilder.vbs
+++ b/src/LetterBuilder/LetterBuilder.vbs
@@ -1393,7 +1393,7 @@ Function validateForm()
     ' Validate EffectiveDate
     Set targetElement = document.getElementById("EffectiveDate")
     If validateAndFormatDate(targetElement.value) = "" Then
-        targetElement.parentElement.parentElement.className = "col-xs-6 form-field form-field-error"
+        targetElement.parentElement.parentElement.className = "col-xs-6 form-field"
         ToggleWordGenerateButtons(false)
     Else
         targetElement.parentElement.className = "col-xs-6 form-field"

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -98,6 +98,18 @@ div.pageContent {
     overflow-y: auto;
 }
 
+.placeholder {
+    position: absolute;
+    bottom: -2px;
+    left: 23px;
+    width: calc(100% - 60px);
+    height: 24px;
+    overflow: hidden;
+    text-align: left;
+    color: #8A8A8A;
+    font-size: 20px;
+}
+
 ul#page2Subnotes {
     padding-top: 32px;
     width: 445px;
@@ -235,7 +247,7 @@ div.actionBar {
 button.actionButton {
     padding: 12px 21px;
     margin: auto 0;
-    min-width: 194px;
+    /* min-width: 194px; */
     height: 58px;
     border: 1px solid #26374A;
     font-size: 22px;
@@ -271,14 +283,18 @@ div.page1-recheckButtonbar {
 }
 
 button.secondaryButton {
-    min-width: 105px;
-    padding: 12px 21px;
-    height: 43px;
+    box-sizing: border-box;
+    padding: 8px 20px;
     font-size: 16px;
     background-color: #EAEBED;
     border-color: #DCDEE1;
     color: #335075;
     border-radius: 5px;
+}
+
+button.secondaryButton span{
+   padding-bottom: 64px;
+   padding-top:0px
 }
 
 button.secondaryButton>img.button-icon {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -370,7 +370,7 @@ div.form-field>span.validationStatusErrorMessage {
 }
 
 div.form-field-error>span.validationStatusErrorMessage {
-    display: inherit;
+    display: inline;
 }
 
 ul.validationEntries>li.success>span.validationStatusSuccess,


### PR DESCRIPTION
**Additions**
-Added a polyfill for placeholder text
-LetterBuilder.js for handling of visual elements

**Fixes**
(Page 2) Fix retry button not hidden on COIF letters
(Page 2) Fix retry crash on click
(Page 2) Padded added to retry button
(Page 2) "Let's get started" button now disabled when files are missing
(Page 3) Moved "Next" button to right side of page
(Page 3) Changed "Next" button size
(Page 4) Added default selection for DCP Plan select
(Page 4) General layout improvements to page
(Page 4) Spinner now appears when reset button is clicked
(Page 5) PDF now follows required naming convention